### PR TITLE
Batch migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ npm-debug.log
 
 # Config files
 config/push.json
+
+Pods

--- a/iOS/Podfile
+++ b/iOS/Podfile
@@ -1,0 +1,8 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '8.0'
+# Uncomment this line if you're using Swift
+# use_frameworks!
+
+target 'chronreact' do
+  pod 'Batch', '~> 1.5'
+end

--- a/iOS/Podfile.lock
+++ b/iOS/Podfile.lock
@@ -1,0 +1,10 @@
+PODS:
+  - Batch (1.5.1)
+
+DEPENDENCIES:
+  - Batch (~> 1.5)
+
+SPEC CHECKSUMS:
+  Batch: 968cfffd316d2f0e8cd652c97608c6c19e2ec099
+
+COCOAPODS: 0.39.0

--- a/iOS/chronreact.xcodeproj/project.pbxproj
+++ b/iOS/chronreact.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		7693B4531CA79D1A00B54C3F /* libRCTPushNotification.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7693B44D1CA79CDB00B54C3F /* libRCTPushNotification.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		D571A6801C8BD1EB1BA877CB /* libPods-chronreact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B7E684D8910E3E533E6ACF7 /* libPods-chronreact.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -135,6 +136,9 @@
 		7693B4431CA79CDB00B54C3F /* RCTPushNotification.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTPushNotification.xcodeproj; path = "../node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		8B7E684D8910E3E533E6ACF7 /* libPods-chronreact.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-chronreact.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D5305C5475F64AE86250A30A /* Pods-chronreact.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-chronreact.debug.xcconfig"; path = "Pods/Target Support Files/Pods-chronreact/Pods-chronreact.debug.xcconfig"; sourceTree = "<group>"; };
+		E742DB32AADD552898B50304 /* Pods-chronreact.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-chronreact.release.xcconfig"; path = "Pods/Target Support Files/Pods-chronreact/Pods-chronreact.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,6 +164,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
+				D571A6801C8BD1EB1BA877CB /* libPods-chronreact.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,12 +266,29 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		7693B4441CA79CDB00B54C3F /* Products */ = {
+		18CB61F1B34A34318419AB0B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D5305C5475F64AE86250A30A /* Pods-chronreact.debug.xcconfig */,
+				E742DB32AADD552898B50304 /* Pods-chronreact.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		4C600DD31C350E050093F8A8 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				7693B44D1CA79CDB00B54C3F /* libRCTPushNotification.a */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		53C03C5A286BB7A866A75EF4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8B7E684D8910E3E533E6ACF7 /* libPods-chronreact.a */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		78C398B11ACF4ADC00677621 /* Products */ = {
@@ -310,6 +332,8 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* chronreactTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
+				18CB61F1B34A34318419AB0B /* Pods */,
+				53C03C5A286BB7A866A75EF4 /* Frameworks */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -349,10 +373,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "chronreact" */;
 			buildPhases = (
+				B34236088C308B1C922F735D /* Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				2F0DA722EA82587155047EA7 /* Embed Pods Frameworks */,
+				C3530AE471C3B47E2663EE1A /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -557,6 +584,51 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
 		};
+		2F0DA722EA82587155047EA7 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-chronreact/Pods-chronreact-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B34236088C308B1C922F735D /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		C3530AE471C3B47E2663EE1A /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-chronreact/Pods-chronreact-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -639,6 +711,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5305C5475F64AE86250A30A /* Pods-chronreact.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEAD_CODE_STRIPPING = NO;
@@ -650,13 +723,18 @@
 				);
 				INFOPLIST_FILE = chronreact/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.dukechronicle.thechronicle;
 				PRODUCT_NAME = chronreact;
 			};
 			name = Debug;
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E742DB32AADD552898B50304 /* Pods-chronreact.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				HEADER_SEARCH_PATHS = (
@@ -667,7 +745,11 @@
 				);
 				INFOPLIST_FILE = chronreact/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.dukechronicle.thechronicle;
 				PRODUCT_NAME = chronreact;
 			};
 			name = Release;

--- a/iOS/chronreact.xcodeproj/project.pbxproj
+++ b/iOS/chronreact.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		4C881E221CAADA4F000152EA /* ChronBatchWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C881E211CAADA4F000152EA /* ChronBatchWrapper.m */; };
 		7693B4531CA79D1A00B54C3F /* libRCTPushNotification.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7693B44D1CA79CDB00B54C3F /* libRCTPushNotification.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		D571A6801C8BD1EB1BA877CB /* libPods-chronreact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B7E684D8910E3E533E6ACF7 /* libPods-chronreact.a */; };
@@ -90,7 +91,7 @@
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
 		};
-		7693B44C1CA79CDB00B54C3F /* PBXContainerItemProxy */ = {
+		4C881E291CAADA4F000152EA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7693B4431CA79CDB00B54C3F /* RCTPushNotification.xcodeproj */;
 			proxyType = 2;
@@ -133,6 +134,8 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = chronreact/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = chronreact/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		4C881E201CAADA4F000152EA /* ChronBatchWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ChronBatchWrapper.h; path = chronreact/ChronBatchWrapper.h; sourceTree = "<group>"; };
+		4C881E211CAADA4F000152EA /* ChronBatchWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ChronBatchWrapper.m; path = chronreact/ChronBatchWrapper.m; sourceTree = "<group>"; };
 		7693B4431CA79CDB00B54C3F /* RCTPushNotification.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTPushNotification.xcodeproj; path = "../node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
@@ -249,6 +252,8 @@
 			children = (
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				4C881E201CAADA4F000152EA /* ChronBatchWrapper.h */,
+				4C881E211CAADA4F000152EA /* ChronBatchWrapper.m */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
@@ -275,10 +280,10 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		4C600DD31C350E050093F8A8 /* Products */ = {
+		4C881E1C1CAAD99D000152EA /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				7693B44D1CA79CDB00B54C3F /* libRCTPushNotification.a */,
+				4C881E2A1CAADA4F000152EA /* libRCTPushNotification.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -403,6 +408,14 @@
 						CreatedOnToolsVersion = 6.2;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
+					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = 47P425822X;
+						SystemCapabilities = {
+							com.apple.Push = {
+								enabled = 1;
+							};
+						};
+					};
 				};
 			};
 			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "chronreact" */;
@@ -438,7 +451,7 @@
 					ProjectRef = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
 				},
 				{
-					ProductGroup = 7693B4441CA79CDB00B54C3F /* Products */;
+					ProductGroup = 4C881E1C1CAAD99D000152EA /* Products */;
 					ProjectRef = 7693B4431CA79CDB00B54C3F /* RCTPushNotification.xcodeproj */;
 				},
 				{
@@ -527,11 +540,17 @@
 			remoteRef = 146834031AC3E56700842450 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		4C881E2A1CAADA4F000152EA /* libRCTPushNotification.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTPushNotification.a;
+			remoteRef = 4C881E291CAADA4F000152EA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		7693B44D1CA79CDB00B54C3F /* libRCTPushNotification.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRCTPushNotification.a;
-			remoteRef = 7693B44C1CA79CDB00B54C3F /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		78C398B91ACF4ADC00677621 /* libRCTLinking.a */ = {
@@ -646,6 +665,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				4C881E221CAADA4F000152EA /* ChronBatchWrapper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/chronreact.xcworkspace/contents.xcworkspacedata
+++ b/iOS/chronreact.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:chronreact.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/iOS/chronreact/ChronBatchWrapper.h
+++ b/iOS/chronreact/ChronBatchWrapper.h
@@ -1,0 +1,5 @@
+#import "RCTBridge.h"
+
+@interface ChronBatchWrapper : NSObject <RCTBridgeModule>
+
+@end

--- a/iOS/chronreact/ChronBatchWrapper.m
+++ b/iOS/chronreact/ChronBatchWrapper.m
@@ -1,0 +1,17 @@
+#import "ChronBatchWrapper.h"
+#import "RCTLog.h"
+
+@import Batch;
+
+@implementation ChronBatchWrapper
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(initialize:(NSString *)apiKey)
+{
+  [BatchPush setupPush];
+  [Batch startWithAPIKey:apiKey];
+  [BatchPush registerForRemoteNotifications];
+}
+
+@end

--- a/iOS/chronreact/Info.plist
+++ b/iOS/chronreact/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -22,6 +22,13 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -36,13 +43,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
-  <key>NSAppTransportSecurity</key>
-  <dict>
-    <!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
-    <key>NSAllowsArbitraryLoads</key>
-    <true/>
-  </dict>
 </dict>
 </plist>

--- a/index.ios.js
+++ b/index.ios.js
@@ -76,11 +76,7 @@ const chronreact = React.createClass({
       }
     });
 
-    PushNotificationIOS.requestPermissions();
-    PushNotificationIOS.addEventListener('register', function(token) {
-      registerPushIOS(token);
-    });
-
+    registerPushIOS();
     PushNotificationIOS.addEventListener('notification', this.onNotification);
   },
 

--- a/src/PushNotification.js
+++ b/src/PushNotification.js
@@ -1,29 +1,8 @@
 const {
-  PARSE_APP_ID,
-  PARSE_REST_KEY,
+  BATCH_API_KEY,
 } = require('../config/push.json');
+const React = require('react-native');
 
-export const registerPushIOS = function(deviceToken) {
-  const url = 'https://api.parse.com/1/installations';
-  const data = {
-    deviceType: 'ios',
-    deviceToken,
-    channels: [''],
-  };
-  return fetch(url, {
-    method: 'post',
-    headers: {
-      'Accept': 'application/json',
-      'X-Parse-Application-Id': PARSE_APP_ID,
-      'X-Parse-REST-API-Key': PARSE_REST_KEY,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(data),
-  })
-  .then(function(res) {
-    return res;
-  })
-  .catch(function(err) {
-    console.error('Device registration error:', err);
-  });
+export const registerPushIOS = function() {
+  React.NativeModules.ChronBatchWrapper.initialize(BATCH_API_KEY);
 };


### PR DESCRIPTION
To manage the SDK, we're using [Cocoapods](https://guides.cocoapods.org/using/getting-started.html). Once Cocoapods is installed, `cd` into the `ios` directory and `pod install`. We should also start using `ios/chronreact.xcworkspace` instead of `ios/chronreact.xcodeproj`.

Configuration values in `config/push.json` [have also been changed](https://github.com/dukechronicle/chron-react/commit/a7085601d5bac2186fc6487494721303d061c41b#diff-8531982c1a8d88f9b3c69f31b823de4bL2), I can distribute test keys for you to use.
