### PR TITLE
Fix image width

### DIFF
--- a/iOS/chronreact/AppDelegate.m
+++ b/iOS/chronreact/AppDelegate.m
@@ -8,7 +8,7 @@
  */
 
 #import "AppDelegate.h"
-
+#import "RCTLinkingManager.h"
 #import "RCTRootView.h"
 
 @implementation AppDelegate
@@ -52,6 +52,13 @@
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+{
+  return [RCTLinkingManager application:application openURL:url
+                      sourceApplication:sourceApplication annotation:annotation];
 }
 
 @end

--- a/iOS/chronreact/AppDelegate.m
+++ b/iOS/chronreact/AppDelegate.m
@@ -8,13 +8,16 @@
  */
 
 #import "AppDelegate.h"
+@import Batch;
 #import "RCTLinkingManager.h"
+#import "RCTPushNotificationManager.h"
 #import "RCTRootView.h"
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  [BatchPush enableAutomaticDeeplinkHandling:NO];
   NSURL *jsCodeLocation;
 
   /**
@@ -40,10 +43,18 @@
    */
 
 //   jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  NSDictionary *remoteNotif = [launchOptions objectForKey: UIApplicationLaunchOptionsRemoteNotificationKey];
 
+  //Accept push notification when app is not open
+  NSDictionary *pushProps = nil;
+  if (remoteNotif) {
+    NSString *deeplink = [BatchPush deeplinkFromUserInfo:remoteNotif];
+    pushProps = @{@"pushNotification" : deeplink};
+  }
+  
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"chronreact"
-                                               initialProperties:nil
+                                               initialProperties:pushProps
                                                    launchOptions:launchOptions];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
@@ -60,5 +71,28 @@
   return [RCTLinkingManager application:application openURL:url
                       sourceApplication:sourceApplication annotation:annotation];
 }
+
+ // Required to register for notifications
+ - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+ {
+  [RCTPushNotificationManager didRegisterUserNotificationSettings:notificationSettings];
+ }
+ // Required for the register event.
+ - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+ {
+  [RCTPushNotificationManager didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+ }
+ // Required for the notification event.
+ - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
+ {
+   NSString *deeplink = [BatchPush deeplinkFromUserInfo:notification];
+   NSDictionary *pushProps = @{@"pushNotification" : deeplink};
+  [RCTPushNotificationManager didReceiveRemoteNotification:pushProps];
+ }
+ // Required for the localNotification event.
+ - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+ {
+  [RCTPushNotificationManager didReceiveLocalNotification:notification];
+ }
 
 @end

--- a/index.ios.js
+++ b/index.ios.js
@@ -68,7 +68,7 @@ const chronreact = React.createClass({
   componentDidMount() {
     tabCursor.on('change', this.updateTab);
     StatusBarIOS.setStyle('light-content');
-
+    Linking.addEventListener('url', this._handleOpenURL);
     Linking.getInitialURL().then((url) => {
       if (!_.isNull(url)) {
         const slug = url.replace(/dukechronicle:\/\//, '');
@@ -82,6 +82,15 @@ const chronreact = React.createClass({
 
   componentWillUnmount() {
     tabCursor.off('change', this.updateTab);
+    Linking.removeEventListener('url', this._handleOpenURL);
+  },
+
+  _handleOpenURL(e) {
+    const url = e.url;
+    if (!_.isNull(url)) {
+      const slug = url.replace(/dukechronicle:\/\//, '');
+      this.openPost(slug);
+    }
   },
 
   /*

--- a/index.ios.js
+++ b/index.ios.js
@@ -69,13 +69,21 @@ const chronreact = React.createClass({
     tabCursor.on('change', this.updateTab);
     StatusBarIOS.setStyle('light-content');
     Linking.addEventListener('url', this._handleOpenURL);
+
+    const url = this.props.pushNotification;
+    if (!(_.isUndefined(url) || _.isNull(url))) {
+      const slug = url.replace(/dukechronicle:\/\//, '')
+        .replace(/\/article\//, '');
+      this.openPost(slug);
+    }
+
     Linking.getInitialURL().then((url) => {
       if (!_.isNull(url)) {
-        const slug = url.replace(/dukechronicle:\/\//, '');
+        const slug = url.replace(/dukechronicle:\/\//, '')
+          .replace(/\/article\//, '');
         this.openPost(slug);
       }
     });
-
     registerPushIOS();
     PushNotificationIOS.addEventListener('notification', this.onNotification);
   },
@@ -83,25 +91,26 @@ const chronreact = React.createClass({
   componentWillUnmount() {
     tabCursor.off('change', this.updateTab);
     Linking.removeEventListener('url', this._handleOpenURL);
+    PushNotificationIOS.removeEventListener('notification', this.onNotification);
   },
 
   _handleOpenURL(e) {
     const url = e.url;
     if (!_.isNull(url)) {
-      const slug = url.replace(/dukechronicle:\/\//, '');
+      const slug = url.replace(/dukechronicle:\/\//, '')
+        .replace(/\/article\//, '');
       this.openPost(slug);
     }
   },
 
   /*
    * Expects notification object to have a '_data' key that maps to an object,
-   * which should have 'postUrl' as a key, which should map to a full url.
+   * which should have 'pushNotification' as a key, which should map to a full url.
    */
   onNotification(notification) {
-    const url = notification._data.postUrl;
-    if (!_.isUndefined(url)) {
-      const slug = (new URL(url))
-        .pathname
+    const url = notification._data.pushNotification;
+    if (!(_.isUndefined(url) || _.isNull(url))) {
+      const slug = url.replace(/dukechronicle:\/\//, '')
         .replace(/\/article\//, '');
       this.openPost(slug);
     }

--- a/src/components/PostDetail.js
+++ b/src/components/PostDetail.js
@@ -30,10 +30,13 @@ const innerStyles = (fullWidth) => {
   }
   #image {
     flex: 1;
-    width: ${fullWidth}px;
+    max-width: ${fullWidth}px;
     margin-top: 15px;
     margin-bottom: 5px;
     margin-left: ${-gutterWidth}px;
+  }
+  img {
+    max-width: ${fullWidth - 2*gutterWidth}px;
   }
   body {
     font-family: 'Helvetica';


### PR DESCRIPTION
See the last commit on PostDetail.js (the other two are for push notification). 

Fix the image width to disable horizontal scrolling:

Images that are embedded in post.body have default styling (ex. style="width: 360px; display: block; margin: auto;" ). Override this width by setting max-width to window width - margins for <img>'s. 

Used 2016/03/ldoc-lineup-analysis-2016-edition article for test example. 
