### PR TITLE
Fix image width

### DIFF
--- a/src/components/PostDetail.js
+++ b/src/components/PostDetail.js
@@ -30,10 +30,13 @@ const innerStyles = (fullWidth) => {
   }
   #image {
     flex: 1;
-    width: ${fullWidth}px;
+    max-width: ${fullWidth}px;
     margin-top: 15px;
     margin-bottom: 5px;
     margin-left: ${-gutterWidth}px;
+  }
+  img {
+    max-width: ${fullWidth - 2 * gutterWidth}px;
   }
   body {
     font-family: 'Helvetica';


### PR DESCRIPTION
Fix the image width to disable horizontal scrolling:

Images that are embedded in post.body have default styling (ex. style="width: 360px; display: block; margin: auto;" ). Override this width by setting max-width to window width - margins for 's.

Used 2016/03/ldoc-lineup-analysis-2016-edition article for test example.
