### PR TITLE
Remove qduke and schedulator links

### DIFF
--- a/src/actions/LinksActionCreators.js
+++ b/src/actions/LinksActionCreators.js
@@ -4,12 +4,12 @@ const linksCursor = store.select('models', 'links');
 const LinksActionCreators = {
   getLinks: () => {
     const links = [
-      ['http://qduke.com', 'qDuke.com'],
+      //['http://qduke.com', 'qDuke.com'],
       ['http://dukechroniclealumni.com/', 'Alumni'],
       ['http://dukechronicle.campusave.com/', 'Classifieds'],
       ['http://nearduke.com/dining', 'Dining'],
       ['http://nearduke.com/housing', 'Housing'],
-      ['http://www.dukeschedulator.com/', 'Schedulator'],
+      //['http://www.dukeschedulator.com/', 'Schedulator'],
     ].map(([url, name]) => { return {url, name}; });
     linksCursor.set(links);
   },


### PR DESCRIPTION
These links are no longer supported by the Chronicle.
